### PR TITLE
Add a python mockup based on QTableView: supports copy/pasting to/from excel, undo operations

### DIFF
--- a/ModelDesignWizard_python_QTableView/ModelDesignWizard.json
+++ b/ModelDesignWizard_python_QTableView/ModelDesignWizard.json
@@ -1,0 +1,23214 @@
+{
+  "DOE": {
+    "building_types": [
+      "SecondarySchool",
+      "PrimarySchool",
+      "SmallOffice",
+      "MediumOffice",
+      "LargeOffice",
+      "SmallHotel",
+      "LargeHotel",
+      "Warehouse",
+      "RetailStandalone",
+      "RetailStripmall",
+      "QuickServiceRestaurant",
+      "FullServiceRestaurant",
+      "MidriseApartment",
+      "HighriseApartment",
+      "Hospital",
+      "Outpatient",
+      "SuperMarket",
+      "Laboratory",
+      "LargeDataCenterLowITE",
+      "LargeDataCenterHighITE",
+      "SmallDataCenterLowITE",
+      "SmallDataCenterHighITE"
+    ],
+    "templates": [
+      "DOE Ref Pre-1980",
+      "DOE Ref 1980-2004",
+      "90.1-2004",
+      "90.1-2007",
+      "90.1-2010",
+      "90.1-2013",
+      "90.1-2016",
+      "90.1-2019",
+      "ComStock DOE Ref Pre-1980",
+      "ComStock DOE Ref 1980-2004",
+      "ComStock 90.1-2004",
+      "ComStock 90.1-2007",
+      "ComStock 90.1-2010",
+      "ComStock 90.1-2013",
+      "NREL ZNE Ready 2017"
+    ],
+    "climate_zones": [
+      "ASHRAE 169-2013-1A",
+      "ASHRAE 169-2013-1B",
+      "ASHRAE 169-2013-2A",
+      "ASHRAE 169-2013-2B",
+      "ASHRAE 169-2013-3A",
+      "ASHRAE 169-2013-3B",
+      "ASHRAE 169-2013-3C",
+      "ASHRAE 169-2013-4A",
+      "ASHRAE 169-2013-4B",
+      "ASHRAE 169-2013-4C",
+      "ASHRAE 169-2013-5A",
+      "ASHRAE 169-2013-5B",
+      "ASHRAE 169-2013-5C",
+      "ASHRAE 169-2013-6A",
+      "ASHRAE 169-2013-6B",
+      "ASHRAE 169-2013-7A",
+      "ASHRAE 169-2013-8A",
+      "ASHRAE 169-2013-0A",
+      "ASHRAE 169-2013-0B"
+    ],
+    "space_types": {
+      "DOE Ref Pre-1980": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3528,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1009,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Gym - audience": {
+            "ratio": 0.0637,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.561,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom": {
+            "ratio": 0.6313,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DOE Ref 1980-2004": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3528,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1009,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Gym - audience": {
+            "ratio": 0.0637,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.561,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom": {
+            "ratio": 0.6313,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2004": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2007": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2010": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2013": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2016": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "90.1-2019": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock DOE Ref Pre-1980": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3528,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1009,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Gym - audience": {
+            "ratio": 0.0637,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.561,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom": {
+            "ratio": 0.6313,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock DOE Ref 1980-2004": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3528,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1009,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Gym - audience": {
+            "ratio": 0.0637,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.561,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom": {
+            "ratio": 0.6313,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock 90.1-2004": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock 90.1-2007": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock 90.1-2010": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "ComStock 90.1-2013": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "NREL ZNE Ready 2017": {
+        "SecondarySchool": {
+          "Auditorium": {
+            "ratio": 0.0504,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Cafeteria": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3041,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0487,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.2144,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.1646,
+            "space_type_gen": true,
+            "default": false,
+            "story_height": 26.0
+          },
+          "Kitchen": {
+            "ratio": 0.011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0349,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0543,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0214,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "PrimarySchool": {
+          "Cafeteria": {
+            "ratio": 0.0458,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.4793,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ComputerRoom": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.1633,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Gym": {
+            "ratio": 0.052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Library": {
+            "ratio": 0.0581,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0367,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0642,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0277,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallOffice": {
+          "WholeBuilding - Sm Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "MediumOffice": {
+          "WholeBuilding - Md Office": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeOffice": {
+          "WholeBuilding - Lg Office": {
+            "ratio": 0.9737,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeLarge Data Center": {
+            "ratio": 0.0094,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeLarge Main Data Center": {
+            "ratio": 0.0169,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SmallHotel": {
+          "Corridor": {
+            "ratio": 0.1313,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorCore": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exercise": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestLounge": {
+            "ratio": 0.0406,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRoom123Occ": {
+            "ratio": 0.4081,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRoom123Vac": {
+            "ratio": 0.2231,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0244,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Meeting": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PublicRestroom": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StaffLounge": {
+            "ratio": 0.0081,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0325,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "LargeHotel": {
+          "Banquet": {
+            "ratio": 0.0585,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Basement": {
+            "ratio": 0.1744,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0166,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1736,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "GuestRoom": {
+            "ratio": 0.4099,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0069,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.1153,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Mechanical": {
+            "ratio": 0.0145,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.0128,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Storage": {
+            "ratio": 0.0084,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Warehouse": {
+          "Bulk": {
+            "ratio": 0.6628,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Fine": {
+            "ratio": 0.2882,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.049,
+            "space_type_gen": true,
+            "default": false,
+            "wwr": 0.71,
+            "story_height": 14.0
+          }
+        },
+        "RetailStandalone": {
+          "Back_Space": {
+            "ratio": 0.1656,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Entry": {
+            "ratio": 0.0052,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Point_of_Sale": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Retail": {
+            "ratio": 0.7635,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RetailStripmall": {
+          "Strip mall - type 1": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 2": {
+            "ratio": 0.25,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Strip mall - type 3": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "QuickServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "FullServiceRestaurant": {
+          "Dining": {
+            "ratio": 0.7272,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.2728,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MidriseApartment": {
+          "Apartment": {
+            "ratio": 0.8727,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0282,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "HighriseApartment": {
+          "Apartment": {
+            "ratio": 0.8896,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.0991,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Office": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hospital": {
+          "Basement": {
+            "ratio": 0.1667,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Corridor": {
+            "ratio": 0.1741,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "Dining": {
+            "ratio": 0.0311,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Exam": {
+            "ratio": 0.0099,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_NurseStn": {
+            "ratio": 0.0551,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Trauma": {
+            "ratio": 0.0025,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ER_Triage": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_NurseStn": {
+            "ratio": 0.0298,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_Open": {
+            "ratio": 0.0275,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ICU_PatRm": {
+            "ratio": 0.0115,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0414,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lab": {
+            "ratio": 0.0236,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0657,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStn": {
+            "ratio": 0.1723,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.0286,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0273,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatCorridor": {
+            "ratio": 0.0,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatRoom": {
+            "ratio": 0.0845,
+            "space_type_gen": true,
+            "default": true
+          },
+          "PhysTherapy": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Radiology": {
+            "ratio": 0.0217,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Outpatient": {
+          "Anesthesia": {
+            "ratio": 0.0026,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BioHazard": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Cafe": {
+            "ratio": 0.0103,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CleanWork": {
+            "ratio": 0.0071,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.0082,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DresingRoom": {
+            "ratio": 0.0021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.0109,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ElevatorPumpRoom": {
+            "ratio": 0.0022,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Exam": {
+            "ratio": 0.1029,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Hall": {
+            "ratio": 0.1924,
+            "space_type_gen": true,
+            "default": false,
+            "circ": true
+          },
+          "IT_Room": {
+            "ratio": 0.0027,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Janitor": {
+            "ratio": 0.0672,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lobby": {
+            "ratio": 0.0152,
+            "space_type_gen": true,
+            "default": false
+          },
+          "LockerRoom": {
+            "ratio": 0.019,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Lounge": {
+            "ratio": 0.0293,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MedGas": {
+            "ratio": 0.0014,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI": {
+            "ratio": 0.0107,
+            "space_type_gen": true,
+            "default": false
+          },
+          "MRI_Control": {
+            "ratio": 0.0041,
+            "space_type_gen": true,
+            "default": false
+          },
+          "NurseStation": {
+            "ratio": 0.0189,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.1828,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OR": {
+            "ratio": 0.0346,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PACU": {
+            "ratio": 0.0232,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PhysicalTherapy": {
+            "ratio": 0.0462,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PreOp": {
+            "ratio": 0.0129,
+            "space_type_gen": true,
+            "default": false
+          },
+          "ProcedureRoom": {
+            "ratio": 0.007,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Reception": {
+            "ratio": 0.0365,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Soil Work": {
+            "ratio": 0.0088,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Stair": {
+            "ratio": 0.0146,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Toilet": {
+            "ratio": 0.0193,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Undeveloped": {
+            "ratio": 0.0835,
+            "space_type_gen": false,
+            "default": false
+          },
+          "Xray": {
+            "ratio": 0.022,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SuperMarket": {
+          "Bakery": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Deli": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DryStorage": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Office": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Produce": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Sales": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Corridor": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Dining": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Elec/MechRoom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Meeting": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Restroom": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Vestibule": {
+            "ratio": 0.99,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Laboratory": {
+          "Office": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Open lab": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Equipment corridor": {
+            "ratio": 0.05,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Lab with fume hood": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterLowITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "LargeDataCenterHighITE": {
+          "StandaloneDataCenter": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterLowITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SmallDataCenterHighITE": {
+          "ComputerRoom": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      }
+    }
+  },
+  "DEER": {
+    "building_types": [
+      "Asm",
+      "DMo",
+      "ECC",
+      "EPr",
+      "ERC",
+      "ESe",
+      "EUn",
+      "GHs",
+      "Gro",
+      "Hsp",
+      "Htl",
+      "MBT",
+      "MFm",
+      "MLI",
+      "Mtl",
+      "Nrs",
+      "OfL",
+      "OfS",
+      "RFF",
+      "RSD",
+      "Rt3",
+      "RtL",
+      "RtS",
+      "SCn",
+      "SFm",
+      "SUn",
+      "WRf"
+    ],
+    "templates": [
+      "DEER Pre-1975",
+      "DEER 1985",
+      "DEER 1996",
+      "DEER 2003",
+      "DEER 2007",
+      "DEER 2011",
+      "DEER 2014",
+      "DEER 2015",
+      "DEER 2017",
+      "DEER 2020",
+      "DEER 2025",
+      "DEER 2030",
+      "DEER 2035",
+      "DEER 2040",
+      "DEER 2045",
+      "DEER 2050",
+      "DEER 2055",
+      "DEER 2060",
+      "DEER 2065",
+      "DEER 2070",
+      "DEER 2075"
+    ],
+    "climate_zones": [
+      "CEC T24-CEC1",
+      "CEC T24-CEC2",
+      "CEC T24-CEC3",
+      "CEC T24-CEC4",
+      "CEC T24-CEC5",
+      "CEC T24-CEC6",
+      "CEC T24-CEC7",
+      "CEC T24-CEC8",
+      "CEC T24-CEC9",
+      "CEC T24-CEC10",
+      "CEC T24-CEC11",
+      "CEC T24-CEC12",
+      "CEC T24-CEC13",
+      "CEC T24-CEC14",
+      "CEC T24-CEC15",
+      "CEC T24-CEC16"
+    ],
+    "space_types": {
+      "DEER Pre-1975": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 1985": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 1996": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2003": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2007": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2011": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2014": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2015": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2017": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2020": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2025": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2030": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2035": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2040": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2045": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2050": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2055": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2060": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2065": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2070": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      },
+      "DEER 2075": {
+        "Asm": {
+          "Auditorium": {
+            "ratio": 0.7658,
+            "space_type_gen": true,
+            "default": true
+          },
+          "OfficeGeneral": {
+            "ratio": 0.2342,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "DMo": false,
+        "ECC": {
+          "Classroom": {
+            "ratio": 0.5558,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.0319,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Shop": {
+            "ratio": 0.1249,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0876,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0188,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.181,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "EPr": {
+          "Classroom": {
+            "ratio": 0.53,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "ERC": {
+          "Classroom": {
+            "ratio": 0.5,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "ESe": {
+          "Classroom": {
+            "ratio": 0.488,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.1,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Gymnasium": {
+            "ratio": 0.15,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.021,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "EUn": {
+          "Dining": {
+            "ratio": 0.0238,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Classroom": {
+            "ratio": 0.3056,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3422,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CompRoomClassRm": {
+            "ratio": 0.038,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "CorridorStairway": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "FacMaint": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "DormitoryRoom": {
+            "ratio": 0.1699,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "GHs": false,
+        "Gro": {
+          "GrocSales": {
+            "ratio": 0.8002,
+            "space_type_gen": true,
+            "default": true
+          },
+          "RefWalkInCool": {
+            "ratio": 0.0312,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.07,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefFoodPrep": {
+            "ratio": 0.0253,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefWalkInFreeze": {
+            "ratio": 0.0162,
+            "space_type_gen": true,
+            "default": false
+          },
+          "IndLoadDock": {
+            "ratio": 0.057,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Hsp": {
+          "HspSurgOutptLab": {
+            "ratio": 0.2317,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.0172,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.0075,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.3636,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.38,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Htl": {
+          "Dining": {
+            "ratio": 0.004,
+            "space_type_gen": true,
+            "default": false
+          },
+          "BarCasino": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "HotelLobby": {
+            "ratio": 0.0411,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.1011,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laundry": {
+            "ratio": 0.0205,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.64224,
+            "space_type_gen": true,
+            "default": true
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.16056,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.005,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MBT": {
+          "CompRoomData": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Laboratory": {
+            "ratio": 0.4534,
+            "space_type_gen": true,
+            "default": true
+          },
+          "CorridorStairway": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Conference": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.03,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.2666,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.01,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MFm": {
+          "ResLiving": {
+            "ratio": 0.9297,
+            "space_type_gen": true,
+            "default": true
+          },
+          "ResPublicArea": {
+            "ratio": 0.0725,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "MLI": {
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "Mtl": {
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmCorrid": {
+            "ratio": 0.649,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Laundry": {
+            "ratio": 0.016,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmOcc": {
+            "ratio": 0.25208,
+            "space_type_gen": true,
+            "default": false
+          },
+          "GuestRmUnOcc": {
+            "ratio": 0.06302,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Nrs": {
+          "CorridorStairway": {
+            "ratio": 0.0555,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.105,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.045,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.35,
+            "space_type_gen": true,
+            "default": false
+          },
+          "PatientRoom": {
+            "ratio": 0.4445,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "OfL": {
+          "LobbyWaiting": {
+            "ratio": 0.0412,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.3704,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeOpen": {
+            "ratio": 0.5296,
+            "space_type_gen": true,
+            "default": true
+          },
+          "MechElecRoom": {
+            "ratio": 0.0588,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "OfS": {
+          "Hall": {
+            "ratio": 0.3141,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeSmall": {
+            "ratio": 0.6859,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RFF": {
+          "Dining": {
+            "ratio": 0.3997,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.4,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1501,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Restroom": {
+            "ratio": 0.0501,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RSD": {
+          "Restroom": {
+            "ratio": 0.0357,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Dining": {
+            "ratio": 0.5353,
+            "space_type_gen": true,
+            "default": true
+          },
+          "LobbyWaiting": {
+            "ratio": 0.1429,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Kitchen": {
+            "ratio": 0.2861,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "Rt3": {
+          "RetailSales": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "RtL": {
+          "OfficeGeneral": {
+            "ratio": 0.0359,
+            "space_type_gen": true,
+            "default": false
+          },
+          "Work": {
+            "ratio": 0.04,
+            "space_type_gen": true,
+            "default": false
+          },
+          "StockRoom": {
+            "ratio": 0.091,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RetailSales": {
+            "ratio": 0.8219,
+            "space_type_gen": true,
+            "default": true
+          },
+          "Kitchen": {
+            "ratio": 0.0113,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "RtS": {
+          "RetailSales": {
+            "ratio": 0.8,
+            "space_type_gen": true,
+            "default": true
+          },
+          "StockRoom": {
+            "ratio": 0.2,
+            "space_type_gen": true,
+            "default": false
+          }
+        },
+        "SCn": {
+          "WarehouseCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "SFm": false,
+        "SUn": {
+          "WarehouseUnCond": {
+            "ratio": 1.0,
+            "space_type_gen": true,
+            "default": true
+          }
+        },
+        "WRf": {
+          "IndLoadDock": {
+            "ratio": 0.08,
+            "space_type_gen": true,
+            "default": false
+          },
+          "OfficeGeneral": {
+            "ratio": 0.02,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorFreezer": {
+            "ratio": 0.4005,
+            "space_type_gen": true,
+            "default": false
+          },
+          "RefStorCooler": {
+            "ratio": 0.4995,
+            "space_type_gen": true,
+            "default": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/ModelDesignWizard_python_QTableView/ModelDesignWizard.py
+++ b/ModelDesignWizard_python_QTableView/ModelDesignWizard.py
@@ -1,0 +1,590 @@
+# Copyright (C) 2022 The Qt Company Ltd.
+# SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
+
+import csv
+import io
+import json
+import sys
+from dataclasses import dataclass, fields
+from functools import cache
+from pathlib import Path
+
+from loguru import logger
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import QAbstractTableModel, QEvent, QModelIndex, QSortFilterProxyModel, QIdentityProxyModel, Qt
+from PySide6.QtWidgets import QApplication, QTableView
+
+
+@dataclass
+class SpaceTypeRatioRow:
+    """Class for keeping track of an item in inventory."""
+
+    buildingType: str
+    spaceType: str
+    ratio: float
+    floorArea: float
+
+
+@cache
+def _load_support_json():
+    return json.load(Path("ModelDesignWizard.json").open("r"))
+
+
+def prepareDefaultSpaceTypeRatioRows(
+    standardType: str, standard: str, buildingType: str, totalBuildingFloorArea: float
+):
+    data = _load_support_json()
+    rows = []
+    for space_type, info in data[standardType]["space_types"][standard][buildingType].items():
+        ratio = info["ratio"]
+        rows.append(
+            SpaceTypeRatioRow(
+                buildingType=buildingType, spaceType=space_type, ratio=ratio, floorArea=totalBuildingFloorArea * ratio
+            )
+        )
+    return rows
+
+
+class SpaceTypeModel(QAbstractTableModel):
+    """A model to interface a Qt view with pandas dataframe"""
+
+    def __init__(self, parent=None):
+        QAbstractTableModel.__init__(self, parent)
+        self._support_data = _load_support_json()
+
+        # file = QtCore.QFile("ModelDesignWizard.json")
+        # if file.open(QtCore.QIODevice.ReadOnly | QtCore.QIODevice.Text):
+        #     supportJson = QtCore.QJsonDocument.fromJson(file.readAll())
+        #     m_supportJsonObject = supportJson.object()
+        #     file.close()
+        # else:
+        #     logger.error("Failed to open embedded ModelDesignWizard.json")
+
+        self.totalBuildingFloorArea = 10000.0
+        self.selectedStandardType = None
+        self.selectedStandard = None
+        self.selectedPrimaryBuildingType = None
+        self.rows = []
+
+
+    def populateWithDefaults(self, selectedStandardType: str, selectedStandard: str, selectedPrimaryBuildingType: str):
+        self.selectedStandardType = selectedStandardType
+        self.selectedStandard = selectedStandard
+        self.selectedPrimaryBuildingType = selectedPrimaryBuildingType
+        self.totalBuildingFloorArea = 10000.0
+        self.rows = prepareDefaultSpaceTypeRatioRows(
+            standardType=self.selectedStandardType,
+            standard=self.selectedStandard,
+            buildingType=self.selectedPrimaryBuildingType,
+            totalBuildingFloorArea=self.totalBuildingFloorArea,
+        )
+        self.layoutChanged.emit()
+
+    def setTotalBuildingFloorArea(self, floorArea):
+        self.totalBuildingFloorArea = floorArea
+        for row in self.rows:
+            row.floorArea = row.ratio * floorArea
+
+    def rowCount(self, parent=QModelIndex()) -> int:
+        """Override method from QAbstractTableModel
+
+        Return row count of the pandas DataFrame
+        """
+        if parent == QModelIndex():
+            return len(self.rows)
+
+        return 0
+
+    def columnCount(self, parent=QModelIndex()) -> int:
+        """Override method from QAbstractTableModel
+
+        Return column count of the pandas DataFrame
+        """
+        if parent == QModelIndex():
+            return len(fields(SpaceTypeRatioRow))
+        return 0
+
+    def data(self, index: QModelIndex, role=Qt.ItemDataRole):
+        """Override method from QAbstractTableModel
+
+        Return data cell from the pandas DataFrame
+        """
+        if not index.isValid():
+            return None
+
+        if role == Qt.DisplayRole:
+            row = index.row()
+            col = index.column()
+            return getattr(self.rows[row], fields(SpaceTypeRatioRow)[col].name)
+
+        if role == Qt.TextAlignmentRole:
+            return Qt.AlignmentFlag.AlignCenter
+
+        return None
+
+    def flags(self, index):
+        if index.column() == 3:
+            return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        return Qt.ItemIsEditable | Qt.ItemIsEnabled | Qt.ItemIsSelectable
+
+    def setData(self, index: QModelIndex, value, role=Qt.EditRole) -> bool:
+        row = index.row()
+        col = index.column()
+
+        if col >= len(fields(SpaceTypeRatioRow)):
+            print("WRONG")
+            return False
+
+        field = fields(SpaceTypeRatioRow)[col]
+        try:
+            cast_value = field.type(value)
+        except ValueError as e:
+            print(f"Failed to set field '{field.name}' at ({row}, {col}): {e}")
+            return False
+
+        if role == Qt.EditRole:
+            setattr(self.rows[row], fields(SpaceTypeRatioRow)[col].name, cast_value)
+            if col == 2:
+                setattr(self.rows[row], fields(SpaceTypeRatioRow)[3].name, cast_value * self.totalBuildingFloorArea)
+            self.dataChanged.emit(index, index)
+            return True
+        return False
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole):
+        """Override method from QAbstractTableModel
+
+        Return dataframe index as vertical header data and columns as horizontal header data.
+        """
+        if role == Qt.DisplayRole:
+            if orientation == Qt.Horizontal:
+                return fields(SpaceTypeRatioRow)[section].name
+
+            if orientation == Qt.Vertical:
+                return str(section)
+
+        return None
+
+
+def sort_selectedIndexes(selectedIndexes):
+    selectedIndexes.sort(key=lambda index: (index.row(), index.column()))
+
+
+def print_selectedIndexes(selectedIndexes):
+    print([(x.row(), x.column()) for x in selectedIndexes])
+
+
+@dataclass
+class UndoCellInfo:
+    """Class for keeping track of an undo operation"""
+
+    row: int
+    column: int
+    value: str
+
+
+class ComboBoxDelegate(QtWidgets.QStyledItemDelegate):
+    def __init__(self, items):
+        super(ComboBoxDelegate, self).__init__()
+        self.items = items
+
+    def createEditor(self, parent, option, index):
+        editor = QtWidgets.QComboBox(parent)
+        editor.setAutoFillBackground(True)
+        editor.addItems(self.items)
+        return editor
+
+    def setEditorData(self, editor, index):
+        current_index = editor.findText(index.model().data(index), Qt.MatchExactly)
+        editor.setCurrentIndex(current_index)
+
+    def setModelData(self, editor, model, index):
+        # item_index = model.mapToSource(index)
+        # item = model.sourceModel().item(item_index.row(), 0)
+
+        # if index.parent().row() == -1 and item.hasChildren():
+        #     for row in range(item.rowCount()):
+        #         child = item.child(row, 3)
+        #         child.setText(editor.currentText())
+
+        model.setData(index, editor.currentText())
+
+    def updateEditorGeometry(self, editor, option, index):
+        editor.setGeometry(option.rect)
+
+
+class CopyPastableTableView(QTableView):
+    def __init__(self, *args, **kwargs):
+        super(CopyPastableTableView, self).__init__(*args, **kwargs)
+        self.installEventFilter(self)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.forundo = []
+
+        data = _load_support_json()
+        self.building_type_delegate = ComboBoxDelegate(data["DOE"]["building_types"])
+        self.setItemDelegateForColumn(0, self.building_type_delegate)
+
+    def eventFilter(self, source, event):
+        if event.type() == QtCore.QEvent.KeyPress:
+            if event == QtGui.QKeySequence.Copy:  # event.matches(QKeySequence.Copy)
+                self.copySelection()
+                return True
+            elif event == QtGui.QKeySequence.Paste:
+                self.pasteSelection()
+                return True
+            elif event == QtGui.QKeySequence.Delete:
+                self.deleteSelection()
+                return True
+            elif event == QtGui.QKeySequence.Cut:
+                self.copySelection()
+                self.deleteSelection()
+                return True
+            elif event == QtGui.QKeySequence.Undo:
+                self.undoSelection()
+                return True
+        return super(CopyPastableTableView, self).eventFilter(source, event)
+
+    def copySelection(self):
+        selection = self.selectedIndexes()
+        print(selection)
+        if selection:
+            all_rows = []
+            all_columns = []
+            for index in selection:
+                if not index.row() in all_rows:
+                    all_rows.append(index.row())
+                if not index.column() in all_columns:
+                    all_columns.append(index.column())
+            visible_rows = [row for row in all_rows if not self.isRowHidden(row)]
+            visible_columns = [col for col in all_columns if not self.isColumnHidden(col)]
+            table = [[""] * len(visible_columns) for _ in range(len(visible_rows))]
+            for index in selection:
+                if index.row() in visible_rows and index.column() in visible_columns:
+                    selection_row = visible_rows.index(index.row())
+                    selection_column = visible_columns.index(index.column())
+                    table[selection_row][selection_column] = index.data()
+            stream = io.StringIO()
+            csv.writer(stream, delimiter="\t").writerows(table)
+            QApplication.clipboard().setText(stream.getvalue())
+
+    def pasteSelection(self):
+        selection = self.selectedIndexes()
+        if not selection:
+            return
+
+        print_selectedIndexes(selection)
+
+        buffer = QApplication.clipboard().text()
+        reader = csv.reader(io.StringIO(buffer), delimiter="\t")
+        arr = [[cell for cell in row] for row in reader]
+        if not arr:
+            return
+
+        model = self.model()
+
+        visible_rows = list(set([row for index in selection if not self.isRowHidden(row := index.row())]))
+        visible_columns = list(
+            set([column for index in selection if not self.isColumnHidden(column := index.column()) > 0])
+        )
+
+        this_undo = []
+
+        nrows = len(arr)
+        ncols = len(arr[0])
+        is_only_top_cell = len(visible_rows) == 1 and len(visible_columns) == 1
+        is_single_value = nrows == 1 and ncols == 1
+
+        if is_only_top_cell:
+            # Only the top-left cell is highlighted.
+            insert_rows = [visible_rows[0]]
+            row = insert_rows[0] + 1
+            while len(insert_rows) < nrows:
+                if not self.isRowHidden(row):
+                    insert_rows.append(row)
+                row += 1
+            insert_columns = [visible_columns[0]]
+            col = insert_columns[0] + 1
+            while len(insert_columns) < ncols:
+                if not self.isColumnHidden(col):
+                    insert_columns.append(col)
+                col += 1
+            for i, insert_row in enumerate(insert_rows):
+                for j, insert_column in enumerate(insert_columns):
+                    cell = arr[i][j]
+                    old_value = model.index(insert_row, insert_column).data()
+                    this_undo.append(UndoCellInfo(insert_row, insert_column, old_value))
+                    model.setData(model.index(insert_row, insert_column), cell)
+        elif is_single_value:
+            single_value = arr[0][0]
+            for index in selection:
+                selection_row = visible_rows.index(index.row())
+                selection_column = visible_columns.index(index.column())
+                old_value = model.index(index.row(), index.column()).data()
+                this_undo.append(UndoCellInfo(index.row(), index.column(), old_value))
+                model.setData(
+                    model.index(index.row(), index.column()),
+                    single_value,
+                )
+        else:
+            if nrows != len(visible_rows) == 1 or ncols != len(visible_columns):
+                print("Selection size mistmatch")
+                return
+
+            # Assume the selection size matches the clipboard data size.
+            for index in selection:
+                selection_row = visible_rows.index(index.row())
+                selection_column = visible_columns.index(index.column())
+                old_value = model.index(index.row(), index.column()).data()
+                this_undo.append(UndoCellInfo(index.row(), index.column(), old_value))
+                model.setData(
+                    model.index(index.row(), index.column()),
+                    arr[selection_row][selection_column],
+                )
+
+        print(this_undo)
+        self.forundo.append(this_undo)
+
+    def deleteSelection(self):
+        self.forundo.append([self.selectedRanges()[0].topRow(), self.selectedRanges()[0].leftColumn(), []])
+        for i_row in range(self.selectedRanges()[0].topRow(), self.selectedRanges()[0].bottomRow() + 1):
+            undorow = []
+            for i_col in range(self.selectedRanges()[0].leftColumn(), self.selectedRanges()[0].rightColumn() + 1):
+                undorow.append(self.item(i_row, i_col).text())
+                self.setItem(i_row, i_col, QtWidgets.QTableWidgetItem(""))
+            self.forundo[-1][2].append(undorow)
+
+    def undoSelection(self):
+        if len(self.forundo) > 0:
+            prevundo = self.forundo.pop()
+            print(prevundo)
+            model = self.model()
+            self.setCurrentIndex(model.index(prevundo[0].row, prevundo[0].column))
+            for undoCellInfo in prevundo:
+                model.setData(
+                    model.index(undoCellInfo.row, undoCellInfo.column),
+                    undoCellInfo.value,
+                )
+
+
+class MyProxyModel(QSortFilterProxyModel):
+    def __init__(self, parent=None):
+        QSortFilterProxyModel.__init__(self, parent)
+
+
+class AddBuildingFloorAreaAndRemoveButtonProxy(QIdentityProxyModel):
+    def __init__(self, parent=None):
+        super(AddBuildingFloorAreaAndRemoveButtonProxy, self).__init__(parent)
+
+    def rowCount(self, parent=QModelIndex()) -> int:
+        """Override method from QAbstractTableModel
+        """
+        return self.sourceModel().rowCount(parent)
+
+    def columnCount(self, parent=QModelIndex()) -> int:
+        """Override method from QAbstractTableModel
+
+        Return column count of the pandas DataFrame
+        """
+        print(parent, self.sourceModel().columnCount() + 2)
+        if parent == QModelIndex():
+            return self.sourceModel().columnCount() + 2
+        return 0
+
+    def data(self, index: QModelIndex, role=Qt.ItemDataRole):
+        """Override method from QAbstractTableModel
+
+        Return data cell from the pandas DataFrame
+        """
+        print(index.row(), index.column())
+
+        col = index.column()
+        model = self.sourceModel()
+
+        if role != Qt.DisplayRole:
+            return super().data(index, role)
+
+        if col < model.columnCount():
+            return super().data(index, role)
+
+        print(col)
+
+        if col == model.columnCount():
+            return model.index(index.row(), col - 1).data(role) * 10
+
+
+    def flags(self, index):
+        if index.column() < self.sourceModel().columnCount():
+            return super().flags(index)
+
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole):
+        """Override method from QAbstractTableModel
+
+        Return dataframe index as vertical header data and columns as horizontal header data.
+        """
+        model = self.sourceModel()
+
+        if orientation == Qt.Horizontal and section == model.columnCount():
+            return "Proxy area"
+        if orientation == Qt.Horizontal and section == model.columnCount() + 1:
+            return "Remove"
+
+        return super().headerData(section, orientation, role)
+
+
+class TemplateSelection(QtCore.QObject):
+
+    primaryBuildingTypeChanged = QtCore.Signal(str, str, str)
+
+    def __init__(self):
+        super(TemplateSelection, self).__init__()
+
+        self.data = _load_support_json()
+
+        self.mainLayout = QtWidgets.QVBoxLayout()
+
+        firstRowLayout = QtWidgets.QHBoxLayout()
+        self.mainLayout.addLayout(firstRowLayout)
+
+        standardTypeLayout = QtWidgets.QVBoxLayout()
+        firstRowLayout.addLayout(standardTypeLayout)
+        standardTypeLabel = QtWidgets.QLabel("Standard Template Type:")
+        standardTypeLabel.setObjectName("H2")
+        standardTypeLayout.addWidget(standardTypeLabel)
+
+        self.standardTypeComboBox = QtWidgets.QComboBox();
+        self.standardTypeComboBox.addItems(self.data.keys())
+        self.standardTypeComboBox.currentTextChanged.connect(self.onStandardTypeChanged)
+        standardTypeLayout.addWidget(self.standardTypeComboBox);
+
+
+        targetStandardLayout = QtWidgets.QVBoxLayout()
+        firstRowLayout.addLayout(targetStandardLayout)
+        targetStandardLabel = QtWidgets.QLabel("Target Standard:")
+        targetStandardLabel.setObjectName("H2")
+        targetStandardLayout.addWidget(targetStandardLabel)
+
+        self.targetStandardComboBox = QtWidgets.QComboBox();
+        targetStandardLayout.addWidget(self.targetStandardComboBox);
+
+
+        primaryBuildingTypeLayout = QtWidgets.QVBoxLayout()
+        firstRowLayout.addLayout(primaryBuildingTypeLayout)
+        primaryBuildingTypeLabel = QtWidgets.QLabel("Primary Building Template Type:")
+        primaryBuildingTypeLabel.setObjectName("H2")
+        primaryBuildingTypeLayout.addWidget(primaryBuildingTypeLabel)
+
+        self.primaryBuildingTypeComboBox = QtWidgets.QComboBox();
+        primaryBuildingTypeLayout.addWidget(self.primaryBuildingTypeComboBox);
+        self.primaryBuildingTypeComboBox.currentTextChanged.connect(self.onPrimaryBuildingTypeChanged)
+
+
+
+        secondRowLayout = QtWidgets.QHBoxLayout()
+        self.mainLayout.addLayout(secondRowLayout)
+        buildingFloorAreaLabel = QtWidgets.QLabel("Building Floor Area:")
+        buildingFloorAreaLabel.setObjectName("H2")
+        secondRowLayout.addWidget(buildingFloorAreaLabel)
+
+        self.buildingFloorAreaEdit = QtWidgets.QLineEdit()
+        positiveDoubleValidator = QtGui.QDoubleValidator()
+        positiveDoubleValidator.setBottom(0)
+        positiveDoubleValidator.setDecimals(2)
+        self.buildingFloorAreaEdit.setValidator(positiveDoubleValidator)
+        self.buildingFloorAreaEdit.setText(str(10000.0))
+        secondRowLayout.addWidget(self.buildingFloorAreaEdit)
+
+
+    def onPrimaryBuildingTypeChanged(self):
+        selectedStandardType = self.standardTypeComboBox.currentText()
+        selectedStandard = self.targetStandardComboBox.currentText()
+        selectedPrimaryBuildingType = self.primaryBuildingTypeComboBox.currentText()
+        self.primaryBuildingTypeChanged.emit(selectedStandardType, selectedStandard, selectedPrimaryBuildingType)
+
+    def onStandardTypeChanged(self, text):
+        self.populateTargetStandards()
+        self.populatePrimaryBuildingTypes()
+
+    def populateTargetStandards(self):
+        self.targetStandardComboBox.blockSignals(True)
+        self.targetStandardComboBox.clear()
+
+        self.targetStandardComboBox.addItem("")
+
+        selectedStandardType = self.standardTypeComboBox.currentText()
+        for temp in self.data[selectedStandardType]["templates"]:
+            self.targetStandardComboBox.addItem(temp);
+        self.targetStandardComboBox.setCurrentIndex(0)
+
+        self.targetStandardComboBox.blockSignals(False)
+
+    def populatePrimaryBuildingTypes(self):
+        self.populateBuildingTypeComboBox(self.primaryBuildingTypeComboBox)
+
+    def populateBuildingTypeComboBox(self, comboBox):
+        comboBox.blockSignals(True)
+        comboBox.clear()
+
+        comboBox.addItem("")
+
+        selectedStandardType = self.standardTypeComboBox.currentText()
+        for temp in self.data[selectedStandardType]["building_types"]:
+            comboBox.addItem(temp);
+        comboBox.setCurrentIndex(0)
+
+        comboBox.blockSignals(False)
+
+
+USE_SORTABLE_PROXY = False
+USE_MY_PROXY = False
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    mainWindow = QtWidgets.QMainWindow()
+    mainWindow.resize(QtGui.QGuiApplication.primaryScreen().availableGeometry().size() * 0.7)
+    centralWidget = QtWidgets.QWidget()
+    mainWindow.setCentralWidget(centralWidget)
+    # centralWidget.resize(800, 500)
+
+    mainLayout = QtWidgets.QVBoxLayout()
+    centralWidget.setLayout(mainLayout)
+
+    template_selection = TemplateSelection()
+    mainLayout.addLayout(template_selection.mainLayout)
+    template_selection.standardTypeComboBox.setCurrentText("DOE");
+
+
+    tableView = CopyPastableTableView()
+    mainLayout.addWidget(tableView)
+    # tableView.resize(800, 500)
+    tableView.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+    tableView.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+    tableView.horizontalHeader().setStretchLastSection(False)
+    # tableView.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+    tableView.horizontalHeader().setDefaultSectionSize(200)
+    tableView.setAlternatingRowColors(True)
+    # tableView.setSelectionBehavior(QTableView.SelectRows)
+
+    model = SpaceTypeModel()
+
+    if USE_SORTABLE_PROXY:
+        proxy = MyProxyModel()
+        proxy.setSourceModel(model)
+        tableView.setModel(proxy)
+        tableView.setSortingEnabled(True)
+        proxy.sort(2, Qt.DescendingOrder)
+    elif USE_MY_PROXY:
+        proxy = AddBuildingFloorAreaAndRemoveButtonProxy()
+        proxy.setSourceModel(model)
+        tableView.setModel(proxy)
+    else:
+        tableView.setModel(model)
+
+    template_selection.primaryBuildingTypeChanged.connect(model.populateWithDefaults)
+    template_selection.buildingFloorAreaEdit.editingFinished.connect(lambda:
+                                                                     model.setTotalBuildingFloorArea(float(template_selection.buildingFloorAreaEdit.text())))
+
+
+    mainWindow.show()
+    app.exec()

--- a/ModelDesignWizard_python_QTableView/requirements.txt
+++ b/ModelDesignWizard_python_QTableView/requirements.txt
@@ -1,0 +1,2 @@
+pyside6==6.5.3
+loguru


### PR DESCRIPTION
![python_mockup](https://github.com/jmarrec/QtTestbed/assets/5479063/7166b036-312a-4229-b38d-5ecb8ec387e7)


Here on Ubuntu, show the copy/paste to/from a spreadsheet editor:

![QtableView_copy_paste_excel](https://github.com/jmarrec/QtTestbed/assets/5479063/31cc297e-4107-4f85-a11f-ee6f09de0ac0)
